### PR TITLE
Custom forecast route with form submit state

### DIFF
--- a/src/Actions/updateAPIState.tsx
+++ b/src/Actions/updateAPIState.tsx
@@ -1,8 +1,12 @@
-import { APIState, GET_APISTATE, GetAPIStateTypes } from '../Store/Types/types';
+import {
+  APIState,
+  GET_API_STATE,
+  GetAPIStateTypes,
+} from '../Store/Types/types';
 
 const updateAPIState = (updatedAPIState: APIState): GetAPIStateTypes => {
   return {
-    type: GET_APISTATE,
+    type: GET_API_STATE,
     payload: updatedAPIState,
   };
 };

--- a/src/Actions/updateFormSubmit.tsx
+++ b/src/Actions/updateFormSubmit.tsx
@@ -1,0 +1,16 @@
+import {
+  FormSubmit,
+  GET_FORM_SUBMIT,
+  GetFormSubmitTypes,
+} from '../Store/Types/types';
+
+const updateFormSubmit = (
+  updatedFormSubmit: FormSubmit
+): GetFormSubmitTypes => {
+  return {
+    type: GET_FORM_SUBMIT,
+    payload: updatedFormSubmit,
+  };
+};
+
+export default updateFormSubmit;

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -8,7 +8,12 @@ import SecondaryInfo from '../../components/SecondaryInfo/SecondaryInfo';
 import CustomButton from '../../components/CustomButton/CustomButton';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../../Reducers/rootReducer';
-import { CombinedCustomTypes } from '../../Store/Types/types';
+import {
+  CombinedCustomTypes,
+  FormSubmit,
+  GetFormSubmitTypes,
+} from '../../Store/Types/types';
+import updateFormSubmit from '../../Actions/updateFormSubmit';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) =>
   createStyles({
@@ -34,9 +39,15 @@ const mapState = (state: RootState): CombinedCustomTypes => ({
   loading: state.apiState.loading,
   success: state.apiState.success,
   fail: state.apiState.fail,
+  isSubmitted: state.formSubmit.isSubmitted,
 });
 
-const connector = connect(mapState);
+const mapDispatch = (dispatch: any) => ({
+  updateFormSubmit: (formSubmit: FormSubmit): GetFormSubmitTypes =>
+    dispatch(updateFormSubmit(formSubmit)),
+});
+
+const connector = connect(mapState, mapDispatch);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -53,7 +53,13 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type Props = PropsFromRedux;
 
-const Forecast: React.FC<Props> = ({ loading, success, fail }) => {
+const Forecast: React.FC<Props> = ({
+  loading,
+  success,
+  updateFormSubmit,
+  isSubmitted,
+  fail,
+}) => {
   const classes = useStyles();
   return (
     <Background>

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -61,6 +61,11 @@ const Forecast: React.FC<Props> = ({
   fail,
 }) => {
   const classes = useStyles();
+
+  const resetFormSubmit = () => {
+    updateFormSubmit({ isSubmitted: !isSubmitted });
+  };
+
   return (
     <Background>
       <Grid container spacing={3} className={classes.root}>

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -88,7 +88,11 @@ const Forecast: React.FC<Props> = ({
                     <section className={classes.info}>
                       <PrimaryInfo />
                       <SecondaryInfo />
-                      <CustomButton link="/" content="Back" />
+                      <CustomButton
+                        onClick={resetFormSubmit}
+                        link="/"
+                        content="Back"
+                      />
                     </section>
                   </React.Fragment>
                 );
@@ -98,7 +102,11 @@ const Forecast: React.FC<Props> = ({
                     <Heading title="Error" />
                     <section className={classes.info}>
                       <p>An error has occurred. Please try again.</p>
-                      <CustomButton link="/" content="Back" />
+                      <CustomButton
+                        onClick={resetFormSubmit}
+                        link="/"
+                        content="Back"
+                      />
                     </section>
                   </React.Fragment>
                 );

--- a/src/Reducers/apiStateReducer.tsx
+++ b/src/Reducers/apiStateReducer.tsx
@@ -1,4 +1,8 @@
-import { GET_APISTATE, GetAPIStateTypes, APIState } from '../Store/Types/types';
+import {
+  GET_API_STATE,
+  GetAPIStateTypes,
+  APIState,
+} from '../Store/Types/types';
 
 export const initialState = {
   loading: false,
@@ -11,7 +15,7 @@ export const apiStateReducer = (
   action: GetAPIStateTypes
 ): APIState => {
   switch (action.type) {
-    case GET_APISTATE:
+    case GET_API_STATE:
       return {
         ...state,
         loading: action.payload.loading,

--- a/src/Reducers/formSubmitReducer.tsx
+++ b/src/Reducers/formSubmitReducer.tsx
@@ -1,0 +1,25 @@
+import {
+  GET_FORM_SUBMIT,
+  GetFormSubmitTypes,
+  FormSubmit,
+} from '../Store/Types/types';
+
+export const initialState = {
+  isSubmitted: false,
+};
+export const formSubmitReducer = (
+  state = initialState,
+  action: GetFormSubmitTypes
+): FormSubmit => {
+  switch (action.type) {
+    case GET_FORM_SUBMIT:
+      return {
+        ...state,
+        isSubmitted: action.payload.isSubmitted,
+      };
+    default:
+      return state;
+  }
+};
+
+export default formSubmitReducer;

--- a/src/Reducers/rootReducer.tsx
+++ b/src/Reducers/rootReducer.tsx
@@ -4,9 +4,12 @@ import locationReducer from './locationReducer';
 
 import apiStateReducer from './apiStateReducer';
 
+import formSubmitReducer from './formSubmitReducer';
+
 export const rootReducer = combineReducers({
   location: locationReducer,
   apiState: apiStateReducer,
+  formSubmit: formSubmitReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/Store/Types/types.ts
+++ b/src/Store/Types/types.ts
@@ -27,10 +27,10 @@ export interface APIState {
   fail: boolean;
 }
 
-export const GET_APISTATE = 'GET API_STATE';
+export const GET_API_STATE = 'GET API STATE';
 
 interface GetAPIState {
-  type: typeof GET_APISTATE;
+  type: typeof GET_API_STATE;
   payload: APIState;
 }
 

--- a/src/Store/Types/types.ts
+++ b/src/Store/Types/types.ts
@@ -36,4 +36,17 @@ interface GetAPIState {
 
 export type GetAPIStateTypes = GetAPIState;
 
+export interface FormSubmit {
+  isSubmitted: boolean;
+}
+
+export const GET_FORM_SUBMIT = 'GET FORM SUBMIT';
+
+interface GetFormSubmitState {
+  type: typeof GET_FORM_SUBMIT;
+  payload: FormSubmit;
+}
+
+export type GetFormSubmitTypes = GetFormSubmitState;
+
 export type CombinedCustomTypes = Location & APIState;

--- a/src/Store/Types/types.ts
+++ b/src/Store/Types/types.ts
@@ -49,4 +49,4 @@ interface GetFormSubmitState {
 
 export type GetFormSubmitTypes = GetFormSubmitState;
 
-export type CombinedCustomTypes = Location & APIState;
+export type CombinedCustomTypes = Location & APIState & FormSubmit;

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -98,6 +98,7 @@ const Form: React.FC<Props> = (Props) => {
   };
 
   const handleSubmit = async () => {
+    updateFormSubmit({ isSubmitted: !isSubmitted });
     getAPIState({ loading: true, success: false, fail: false });
 
     const submittedData = JSON.stringify({ latitude, longitude });

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -10,9 +10,12 @@ import {
   CombinedCustomTypes,
   APIState,
   GetAPIStateTypes,
+  FormSubmit,
+  GetFormSubmitTypes,
 } from '../../Store/Types/types';
 import updateLocation from '../../Actions/updateLocation';
 import updateAPIState from '../../Actions/updateAPIState';
+import updateFormSubmit from '../../Actions/updateFormSubmit';
 import axios from 'axios';
 
 const mapState = (state: RootState): CombinedCustomTypes => ({
@@ -22,6 +25,7 @@ const mapState = (state: RootState): CombinedCustomTypes => ({
   loading: state.apiState.loading,
   success: state.apiState.success,
   fail: state.apiState.fail,
+  isSubmitted: state.formSubmit.isSubmitted,
 });
 
 const mapDispatch = (dispatch: any) => ({
@@ -29,6 +33,8 @@ const mapDispatch = (dispatch: any) => ({
     dispatch(updateAPIState(apiState)),
   getLocationInfo: (locationData: Location): GetLocationTypes =>
     dispatch(updateLocation(locationData)),
+  updateFormSubmit: (formSubmit: FormSubmit): GetFormSubmitTypes =>
+    dispatch(updateFormSubmit(formSubmit)),
 });
 
 const connector = connect(mapState, mapDispatch);
@@ -50,7 +56,15 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) =>
 );
 
 const Form: React.FC<Props> = (Props) => {
-  const { longitude, latitude, getLocationInfo, getAPIState, data } = Props;
+  const {
+    longitude,
+    latitude,
+    getLocationInfo,
+    getAPIState,
+    updateFormSubmit,
+    isSubmitted,
+    data,
+  } = Props;
 
   const classes = useStyles();
 

--- a/src/components/Router/ForecastRoute.tsx
+++ b/src/components/Router/ForecastRoute.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { CombinedCustomTypes } from '../../Store/Types/types';
+import { RootState } from '../../Reducers/rootReducer';
+import { connect, ConnectedProps } from 'react-redux';
+import { withRouter } from 'react-router';
+import Forecast from '../../Pages/Forecast/Forecast';

--- a/src/components/Router/ForecastRoute.tsx
+++ b/src/components/Router/ForecastRoute.tsx
@@ -29,3 +29,5 @@ const ForecastRoute: React.FC<Props> = ({ isSubmitted }) => {
     </Route>
   );
 };
+
+export default withRouter(connector(ForecastRoute));

--- a/src/components/Router/ForecastRoute.tsx
+++ b/src/components/Router/ForecastRoute.tsx
@@ -5,3 +5,19 @@ import { RootState } from '../../Reducers/rootReducer';
 import { connect, ConnectedProps } from 'react-redux';
 import { withRouter } from 'react-router';
 import Forecast from '../../Pages/Forecast/Forecast';
+
+const mapState = (state: RootState): CombinedCustomTypes => ({
+  latitude: state.location.latitude,
+  longitude: state.location.longitude,
+  data: state.location.data,
+  loading: state.apiState.loading,
+  success: state.apiState.success,
+  fail: state.apiState.fail,
+  isSubmitted: state.formSubmit.isSubmitted,
+});
+
+const connector = connect(mapState);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+type Props = PropsFromRedux;

--- a/src/components/Router/ForecastRoute.tsx
+++ b/src/components/Router/ForecastRoute.tsx
@@ -21,3 +21,11 @@ const connector = connect(mapState);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type Props = PropsFromRedux;
+
+const ForecastRoute: React.FC<Props> = ({ isSubmitted }) => {
+  return (
+    <Route exact path="/forecast/:id">
+      {isSubmitted ? <Forecast /> : <Redirect to="/" />}
+    </Route>
+  );
+};

--- a/src/components/Router/Router.tsx
+++ b/src/components/Router/Router.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
+import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import Home from '../../Pages/Home/Home';
-import Forecast from '../../Pages/Forecast/Forecast';
+import ForecastRoute from './ForecastRoute';
 
 const Router: React.FC<{}> = () => {
   return (
     <BrowserRouter>
       <Switch>
         <Route exact path="/" component={Home} />
-        <Route exact path="/forecast/:id" component={Forecast} />
-        <Redirect to="/" />
+        <ForecastRoute />
       </Switch>
     </BrowserRouter>
   );


### PR DESCRIPTION
Created a new component (ForecastRoute) that includes the route that renders the Forecast component, and as well as a redirect to the home page if the user refreshes the page. Previously, if the user refreshes the page while on the forecast page, the user still sees the forecast page but an error message shows up. 

To do so, a form submit state was created to keep track of form submissions, and is reset whenever a user navigates back to the home page through the "Back" button, or refreshes the page. The redirect route is then rendered depending on the form submit state.
