### PR TITLE
External link

### DIFF
--- a/src/components/Background/Background.tsx
+++ b/src/components/Background/Background.tsx
@@ -17,16 +17,6 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) =>
       justifyContent: 'center',
       position: 'relative',
     },
-    reference: {
-      backgroundColor: palette.secondary.dark,
-      color: 'white',
-      padding: spacing(4),
-      position: 'absolute',
-      bottom: 0,
-      right: 0,
-      margin: 0,
-      display: 'inline-block',
-    },
     '@media (max-width: 680px)': {
       container: {
         minHeight: '100vh',
@@ -39,20 +29,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) =>
 
 const Background: React.FC<Props> = ({ children }) => {
   const classes = useStyles();
-  return (
-    <div className={classes.container}>
-      {children}
-
-      <a
-        className={classes.reference}
-        href="https://darksky.net/poweredby/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Powered by Dark Sky
-      </a>
-    </div>
-  );
+  return <div className={classes.container}>{children}</div>;
 };
 
 export default Background;

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,2 +1,7 @@
 import React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+
+interface Props {
+  link: string;
+  title: string;
+}

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,0 +1,2 @@
+import React from 'react';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -19,3 +19,22 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) =>
     },
   })
 );
+
+const ExternalLink: React.FC<Props> = ({ link, title }) => {
+  const classes = useStyles();
+  return (
+    <em>
+      <a
+        className={classes.root}
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="external-link"
+      >
+        {title}
+      </a>
+    </em>
+  );
+};
+
+export default ExternalLink;

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -5,3 +5,17 @@ interface Props {
   link: string;
   title: string;
 }
+
+const useStyles = makeStyles(({ palette, spacing }: Theme) =>
+  createStyles({
+    root: {
+      display: 'inline-block',
+      color: palette.secondary.light,
+      fontWeight: 600,
+      textDecoration: 'none',
+      '&:hover': {
+        textDecoration: 'underline',
+      },
+    },
+  })
+);

--- a/src/components/ExternalLink/__tests__/ExternalLink.test.tsx
+++ b/src/components/ExternalLink/__tests__/ExternalLink.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ExternalLink from '../ExternalLink';
+
+test('<ExternalLink /> renders correctly', () => {
+  const defaultProp = {
+    link: 'https://example.com',
+    title: 'Example',
+  };
+  const { getByTestId } = render(<ExternalLink {...defaultProp} />);
+  const externalLink = getByTestId('external-link');
+  const { link, title } = defaultProp;
+  expect(externalLink).toHaveAttribute('href', link);
+  expect(externalLink.textContent).toBe(title);
+});


### PR DESCRIPTION
Added external link component that can be reused across the application. The component is also a replacement for the API reference link. 

A test was also written to ensure that the correct link and text are rendered correctly when they are passed through props.