### PR TITLE
Add hourly and daily weather data

### DIFF
--- a/src/Lambda/weather.ts
+++ b/src/Lambda/weather.ts
@@ -26,6 +26,9 @@ export async function handler(event: any): Promise<APIResponse> {
       uvIndex,
     } = data.currently;
 
+    const hourly = data.hourly.data;
+    const daily = data.daily.data;
+
     const formattedData = {
       latitude,
       longitude,
@@ -37,6 +40,8 @@ export async function handler(event: any): Promise<APIResponse> {
         temperature,
         windSpeed,
         uvIndex,
+        hourly,
+        daily,
       },
     };
 

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -100,6 +100,7 @@ const Forecast: React.FC<Props> = ({
             })()}
           </Paper>
         </Grid>
+        {success && <Grid item xs={12} sm={5} md={4} />}
       </Grid>
     </Background>
   );

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -7,6 +7,7 @@ import PrimaryInfo from '../../components/PrimaryInfo/PrimaryInfo';
 import SecondaryInfo from '../../components/SecondaryInfo/SecondaryInfo';
 import CustomButton from '../../components/CustomButton/CustomButton';
 import ContentWrapper from '../../components/ContentWrapper/ContentWrapper';
+import WeatherTabs from '../../components/WeatherTabs/WeatherTabs';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from '../../Reducers/rootReducer';
 import {
@@ -101,7 +102,9 @@ const Forecast: React.FC<Props> = ({
           </Paper>
         </Grid>
         {success && (
-          <Grid data-testid="forecast-tabs" item xs={10} sm={9} md={4} />
+          <Grid data-testid="forecast-tabs" item xs={10} sm={9} md={4}>
+            <WeatherTabs />
+          </Grid>
         )}
       </Grid>
     </Background>

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -53,7 +53,7 @@ const Forecast: React.FC<Props> = ({
   return (
     <Background>
       <Grid container spacing={8} justify="center" className={classes.root}>
-        <Grid item xs={10} sm={9} md={5}>
+        <Grid item className="forecast-main" xs={10} sm={9} md={5}>
           <Paper>
             {(() => {
               if (loading) {

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -52,8 +52,8 @@ const Forecast: React.FC<Props> = ({
 
   return (
     <Background>
-      <Grid container spacing={2} justify="center" className={classes.root}>
-        <Grid item xs={12} md={5}>
+      <Grid container spacing={8} justify="center" className={classes.root}>
+        <Grid item xs={10} sm={9} md={5}>
           <Paper>
             {(() => {
               if (loading) {
@@ -101,7 +101,7 @@ const Forecast: React.FC<Props> = ({
           </Paper>
         </Grid>
         {success && (
-          <Grid data-testid="forecast-tabs" item xs={12} sm={5} md={4} />
+          <Grid data-testid="forecast-tabs" item xs={10} sm={9} md={4} />
         )}
       </Grid>
     </Background>

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -52,8 +52,8 @@ const Forecast: React.FC<Props> = ({
 
   return (
     <Background>
-      <Grid container spacing={3} className={classes.root}>
-        <Grid item xs={12}>
+      <Grid container spacing={2} justify="center" className={classes.root}>
+        <Grid item xs={12} md={5}>
           <Paper>
             {(() => {
               if (loading) {

--- a/src/Pages/Forecast/Forecast.tsx
+++ b/src/Pages/Forecast/Forecast.tsx
@@ -100,7 +100,9 @@ const Forecast: React.FC<Props> = ({
             })()}
           </Paper>
         </Grid>
-        {success && <Grid item xs={12} sm={5} md={4} />}
+        {success && (
+          <Grid data-testid="forecast-tabs" item xs={12} sm={5} md={4} />
+        )}
       </Grid>
     </Background>
   );

--- a/src/Pages/Forecast/Styles/Style.ts
+++ b/src/Pages/Forecast/Styles/Style.ts
@@ -3,13 +3,7 @@ import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 export const useStyles = makeStyles(({ palette }: Theme) =>
   createStyles({
     root: {
-      width: '60%',
       color: palette.secondary.main,
-    },
-    '@media (max-width: 680px)': {
-      root: {
-        width: '80%',
-      },
     },
   })
 );

--- a/src/Pages/Forecast/Styles/Style.ts
+++ b/src/Pages/Forecast/Styles/Style.ts
@@ -5,5 +5,12 @@ export const useStyles = makeStyles(({ palette }: Theme) =>
     root: {
       color: palette.secondary.main,
     },
+    '@media (max-width: 959px)': {
+      root: {
+        '& .forecast-main': {
+          marginBottom: '1rem',
+        },
+      },
+    },
   })
 );

--- a/src/Pages/Forecast/__tests__/Forecast.test.tsx
+++ b/src/Pages/Forecast/__tests__/Forecast.test.tsx
@@ -15,26 +15,28 @@ afterEach(() => {
 
 describe('<Forecast /> UI renders correctly based on API state', () => {
   test('Loading UI renders correctly', () => {
-    const { getByTestId, getByText } = render(<App />);
+    const { getByTestId, getByText, queryByTestId } = render(<App />);
     const button = getByTestId('link');
     fireEvent.click(button);
     expect(getByText('Loading...')).toBeInTheDocument();
     expect(getByText('Please wait as weather data loads')).toBeInTheDocument();
+    expect(queryByTestId('forecast-tabs')).not.toBeInTheDocument();
   });
   test('Forecast UI renders with API data', async () => {
-    const { getByTestId, getByText } = render(<App />);
+    const { getByTestId, getByText, queryByTestId } = render(<App />);
     const button = getByTestId('link');
     fireEvent.click(button);
     expect(getByText('Loading...')).toBeInTheDocument();
     await waitFor(() => getByText('Forecast'));
     const temperature = getByTestId('temperature');
     expect(temperature.textContent).toBe('25.3℃');
+    expect(queryByTestId('forecast-tabs')).toBeInTheDocument();
   });
   test('Error UI renders correctly when API call is rejected', async () => {
     mockedAxios.post.mockImplementation(() =>
       Promise.reject({ payload: 'rejected' })
     );
-    const { getByTestId, getByText } = render(<App />);
+    const { getByTestId, getByText, queryByTestId } = render(<App />);
     const button = getByTestId('link');
     fireEvent.click(button);
     expect(getByText('Loading...')).toBeInTheDocument();
@@ -42,5 +44,6 @@ describe('<Forecast /> UI renders correctly based on API state', () => {
     expect(
       getByText('An error has occurred, and the data cannot be retrieved.')
     ).toBeInTheDocument();
+    expect(queryByTestId('forecast-tabs')).not.toBeInTheDocument();
   });
 });

--- a/src/Reducers/locationReducer.tsx
+++ b/src/Reducers/locationReducer.tsx
@@ -11,6 +11,8 @@ export const initialState = {
     temperature: 0,
     windSpeed: 0,
     uvIndex: 0,
+    hourly: [{ temperature: 0, date: 0 }],
+    daily: [{ temperature: 0, date: 0 }],
   },
 };
 export const locationReducer = (

--- a/src/Store/Types/types.ts
+++ b/src/Store/Types/types.ts
@@ -1,3 +1,4 @@
+import { WeatherTabInfoProps } from '../../types';
 export interface Location {
   latitude: string;
   longitude: string;
@@ -9,6 +10,8 @@ export interface Location {
     temperature: number;
     windSpeed: number;
     uvIndex: number;
+    hourly: WeatherTabInfoProps[];
+    daily: WeatherTabInfoProps[];
   };
 }
 

--- a/src/Utilities.tsx
+++ b/src/Utilities.tsx
@@ -41,3 +41,16 @@ const months = [
   'November',
   'December',
 ];
+
+// Returns formatted date
+
+export const formattedDate = (value: number): FormattedDate => {
+  const time = new Date(value * 1000);
+  return {
+    hour: `${time.getHours()}:00`,
+    day: days[time.getDay()],
+    date: time.getDate(),
+    month: months[time.getMonth()],
+    year: time.getFullYear(),
+  };
+};

--- a/src/Utilities.tsx
+++ b/src/Utilities.tsx
@@ -1,3 +1,5 @@
+import { FormattedDate } from './types';
+
 // Convert to percentage
 
 export const convertToPercentage = (value: number): string => {
@@ -11,3 +13,31 @@ export const convertWithUnit = (value: number, unit: string): string => {
   const formattedValue = `${value} ${unit}`;
   return formattedValue;
 };
+
+//Date arrays
+
+const days = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+const months = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];

--- a/src/Utilities.tsx
+++ b/src/Utilities.tsx
@@ -1,4 +1,4 @@
-import { FormattedDate } from './types';
+import { FormattedDate, WeatherTabInfoProps } from './types';
 
 // Convert to percentage
 
@@ -53,4 +53,25 @@ export const formattedDate = (value: number): FormattedDate => {
     month: months[time.getMonth()],
     year: time.getFullYear(),
   };
+};
+
+// Return a subset of weather data as a new array from the original
+
+export const selectWeatherData = (
+  min: number,
+  max: number,
+  arr: []
+): WeatherTabInfoProps[] => {
+  const newWeatherArray = arr.splice(min, max);
+  const formattedWeatherArray = newWeatherArray.map((data) => {
+    const { time } = data;
+    const temperature = data['apparentTemperatureHigh']
+      ? data['apparentTemperatureHigh']
+      : data['temperature'];
+    return {
+      temperature,
+      date: time,
+    };
+  });
+  return formattedWeatherArray;
 };

--- a/src/__mocks__/axios.tsx
+++ b/src/__mocks__/axios.tsx
@@ -12,6 +12,8 @@ export default {
           temperature: 25.3,
           windSpeed: 4.99,
           uvIndex: 3,
+          hourly: [{ temperature: 0, date: 0 }],
+          daily: [{ temperature: 0, date: 0 }],
         },
       },
     })

--- a/src/components/Background/Styles/Style.ts
+++ b/src/components/Background/Styles/Style.ts
@@ -12,11 +12,16 @@ export const useStyles = makeStyles(({ palette, spacing }: Theme) =>
       position: 'relative',
       overflowX: 'hidden',
     },
-    '@media (max-width: 680px)': {
+    '@media (max-width: 959px)': {
       container: {
         minHeight: '100vh',
         height: 'auto',
-        padding: spacing(4),
+        padding: spacing(12),
+      },
+    },
+    '@media (max-width: 680px)': {
+      container: {
+        padding: spacing(8),
       },
     },
   })

--- a/src/components/Background/Styles/Style.ts
+++ b/src/components/Background/Styles/Style.ts
@@ -10,6 +10,7 @@ export const useStyles = makeStyles(({ palette, spacing }: Theme) =>
       alignItems: 'center',
       justifyContent: 'center',
       position: 'relative',
+      overflowX: 'hidden',
     },
     '@media (max-width: 680px)': {
       container: {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -18,6 +18,7 @@ import updateLocation from '../../Actions/updateLocation';
 import updateAPIState from '../../Actions/updateAPIState';
 import updateFormSubmit from '../../Actions/updateFormSubmit';
 import axios from 'axios';
+import { selectWeatherData } from '../../Utilities';
 
 const mapState = (state: RootState): CombinedCustomTypes => ({
   latitude: state.location.latitude,
@@ -102,7 +103,13 @@ class Form extends React.Component<Props, FormState> {
         temperature,
         windSpeed,
         uvIndex,
+        hourly,
+        daily,
       } = response.data.data;
+
+      const hourlyData = selectWeatherData(0, 12, hourly);
+      const dailyData = selectWeatherData(1, 7, daily);
+
       this.props.getLocationInfo({
         ...this.props,
         data: {
@@ -113,6 +120,8 @@ class Form extends React.Component<Props, FormState> {
           temperature,
           windSpeed,
           uvIndex,
+          hourly: hourlyData,
+          daily: dailyData,
         },
       });
       this.props.getAPIState({ loading: false, success: true, fail: false });

--- a/src/components/WeatherTabs/CustomTabPanel.tsx
+++ b/src/components/WeatherTabs/CustomTabPanel.tsx
@@ -17,7 +17,7 @@ const CustomTabPanel: React.FC<TabPanelProps> = ({
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
       {...other}
-      className={classes.root}
+      className={`${classes.root} ${classes.scrollBar}`}
     >
       {value === index && (
         <Box component="section" color="secondary">

--- a/src/components/WeatherTabs/CustomTabPanel.tsx
+++ b/src/components/WeatherTabs/CustomTabPanel.tsx
@@ -20,7 +20,7 @@ const CustomTabPanel: React.FC<TabPanelProps> = ({
       className={classes.root}
     >
       {value === index && (
-        <Box component="article">
+        <Box component="section" color="secondary">
           <Paper>{children}</Paper>
         </Box>
       )}

--- a/src/components/WeatherTabs/CustomTabPanel.tsx
+++ b/src/components/WeatherTabs/CustomTabPanel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Paper, Box } from '@material-ui/core';
+import { useStyles } from './Styles/CustomTabPanel';
+import { TabPanelProps } from '../../types';
+
+const CustomTabPanel: React.FC<TabPanelProps> = ({
+  children,
+  value,
+  index,
+  ...other
+}) => {
+  const classes = useStyles();
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+      className={classes.root}
+    >
+      {value === index && (
+        <Box component="article">
+          <Paper>{children}</Paper>
+        </Box>
+      )}
+    </div>
+  );
+};
+
+export default CustomTabPanel;

--- a/src/components/WeatherTabs/Styles/CustomTabPanel.ts
+++ b/src/components/WeatherTabs/Styles/CustomTabPanel.ts
@@ -1,9 +1,25 @@
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
-export const useStyles = makeStyles({
-  root: {
-    width: '100%',
-    height: '300px',
-    overflowY: 'auto',
-  },
-});
+export const useStyles = makeStyles(({ palette }: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      height: '300px',
+      overflowY: 'auto',
+    },
+    scrollBar: {
+      '&::-webkit-scrollbar': {
+        width: '.5rem',
+      },
+      '&::-webkit-scrollbar-track': {
+        backgroundColor: `${palette.grey[200]}`,
+        borderRadius: '.5rem',
+      },
+      '&::-webkit-scrollbar-thumb': {
+        backgroundColor: `${palette.secondary.light}`,
+        borderRadius: '.5rem',
+        outline: `1px solid ${palette.secondary.light}`,
+      },
+    },
+  })
+);

--- a/src/components/WeatherTabs/Styles/CustomTabPanel.ts
+++ b/src/components/WeatherTabs/Styles/CustomTabPanel.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles({
+  root: {
+    width: '100%',
+    height: '300px',
+    overflowY: 'auto',
+  },
+});

--- a/src/components/WeatherTabs/WeatherTabInfo.tsx
+++ b/src/components/WeatherTabs/WeatherTabInfo.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { WeatherTabInfoProps } from '../../types';
+import { CombinedWeatherTabInfoProps, DateTypes } from '../../types';
 import { Box, Typography } from '@material-ui/core';
 
-const WeatherTabInfo: React.FC<WeatherTabInfoProps> = ({
+const WeatherTabInfo: React.FC<CombinedWeatherTabInfoProps> = ({
   temperature,
   date,
+  dateType,
 }) => {
   return (
     <Box

--- a/src/components/WeatherTabs/WeatherTabInfo.tsx
+++ b/src/components/WeatherTabs/WeatherTabInfo.tsx
@@ -22,6 +22,7 @@ const WeatherTabInfo: React.FC<CombinedWeatherTabInfoProps> = ({
       {date}
       <Typography component="p" color="primary" className="temperature">
         {temperature}
+        <sup>&#8451;</sup>
       </Typography>
     </Box>
   );

--- a/src/components/WeatherTabs/WeatherTabInfo.tsx
+++ b/src/components/WeatherTabs/WeatherTabInfo.tsx
@@ -26,7 +26,6 @@ const WeatherTabInfo: React.FC<CombinedWeatherTabInfoProps> = ({
       justifyContent="space-between"
       className="weather-tab-info"
       p={5}
-      mb={4}
       component="article"
     >
       <Typography color="secondary" className="date" component="p">

--- a/src/components/WeatherTabs/WeatherTabInfo.tsx
+++ b/src/components/WeatherTabs/WeatherTabInfo.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { WeatherTabInfoProps } from '../../types';
+import { Box, Typography } from '@material-ui/core';
+
+const WeatherTabInfo: React.FC<WeatherTabInfoProps> = ({
+  temperature,
+  date,
+}) => {
+  return (
+    <Box
+      display="flex"
+      flexWrap="wrap"
+      alignItems="center"
+      justifyContent="space-between"
+      className="weather-tab-info"
+      p={5}
+      mb={4}
+      component="article"
+    >
+      <Typography color="secondary" className="date" component="p" />
+      <Typography component="p" color="primary" className="temperature" />
+    </Box>
+  );
+};
+
+export default WeatherTabInfo;

--- a/src/components/WeatherTabs/WeatherTabInfo.tsx
+++ b/src/components/WeatherTabs/WeatherTabInfo.tsx
@@ -18,7 +18,10 @@ const WeatherTabInfo: React.FC<WeatherTabInfoProps> = ({
       component="article"
     >
       <Typography color="secondary" className="date" component="p" />
-      <Typography component="p" color="primary" className="temperature" />
+      {date}
+      <Typography component="p" color="primary" className="temperature">
+        {temperature}
+      </Typography>
     </Box>
   );
 };

--- a/src/components/WeatherTabs/WeatherTabInfo.tsx
+++ b/src/components/WeatherTabs/WeatherTabInfo.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import { CombinedWeatherTabInfoProps, DateTypes } from '../../types';
 import { Box, Typography } from '@material-ui/core';
+import { formattedDate } from '../../Utilities';
 
 const WeatherTabInfo: React.FC<CombinedWeatherTabInfoProps> = ({
   temperature,
   date,
   dateType,
 }) => {
+  const displayDate = (value: number): string => {
+    const newDate = formattedDate(value);
+    const { day, date, month, year, hour } = newDate;
+    if (dateType === DateTypes.hourly) return hour;
+    const fullDate = `${day}, ${month} ${date} ${year}`;
+    return fullDate;
+  };
+
   return (
     <Box
       display="flex"
@@ -18,8 +27,9 @@ const WeatherTabInfo: React.FC<CombinedWeatherTabInfoProps> = ({
       mb={4}
       component="article"
     >
-      <Typography color="secondary" className="date" component="p" />
-      {date}
+      <Typography color="secondary" className="date" component="p">
+        {displayDate(date)}
+      </Typography>
       <Typography component="p" color="primary" className="temperature">
         {temperature}
         <sup>&#8451;</sup>

--- a/src/components/WeatherTabs/WeatherTabInfo.tsx
+++ b/src/components/WeatherTabs/WeatherTabInfo.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { CombinedWeatherTabInfoProps, DateTypes } from '../../types';
 import { Box, Typography } from '@material-ui/core';
 import { formattedDate } from '../../Utilities';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faClock, faCalendar } from '@fortawesome/free-solid-svg-icons';
 
 const WeatherTabInfo: React.FC<CombinedWeatherTabInfoProps> = ({
   temperature,
@@ -28,6 +30,10 @@ const WeatherTabInfo: React.FC<CombinedWeatherTabInfoProps> = ({
       component="article"
     >
       <Typography color="secondary" className="date" component="p">
+        <FontAwesomeIcon
+          icon={dateType === DateTypes.hourly ? faClock : faCalendar}
+        />
+        &nbsp;
         {displayDate(date)}
       </Typography>
       <Typography component="p" color="primary" className="temperature">

--- a/src/components/WeatherTabs/WeatherTabs.tsx
+++ b/src/components/WeatherTabs/WeatherTabs.tsx
@@ -2,10 +2,25 @@ import React from 'react';
 import { AppBar, Tabs, Tab } from '@material-ui/core';
 import CustomTabPanel from './CustomTabPanel';
 import WeatherTabInfo from './WeatherTabInfo';
-import { TabValueState } from '../../types';
+import { TabValueState, DateTypes } from '../../types';
+import { connect, ConnectedProps } from 'react-redux';
+import { RootState } from '../../Reducers/rootReducer';
+import { Location } from '../../Store/Types/types';
 
-class WeatherTabs extends React.Component<{}, TabValueState> {
-  constructor(props: {}) {
+const mapState = (state: RootState): Location => ({
+  latitude: state.location.latitude,
+  longitude: state.location.longitude,
+  data: state.location.data,
+});
+
+const connector = connect(mapState);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+type Props = PropsFromRedux;
+
+class WeatherTabs extends React.Component<Props, TabValueState> {
+  constructor(props: Props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
   }
@@ -47,4 +62,4 @@ class WeatherTabs extends React.Component<{}, TabValueState> {
   }
 }
 
-export default WeatherTabs;
+export default connector(WeatherTabs);

--- a/src/components/WeatherTabs/WeatherTabs.tsx
+++ b/src/components/WeatherTabs/WeatherTabs.tsx
@@ -55,8 +55,26 @@ class WeatherTabs extends React.Component<Props, TabValueState> {
             <Tab label="Weekly" {...this.a11yProps(1)} />
           </Tabs>
         </AppBar>
-        <CustomTabPanel value={this.state.value} index={0} />
-        <CustomTabPanel value={this.state.value} index={1} />
+        <CustomTabPanel value={this.state.value} index={0}>
+          {this.props.data.hourly.map((data, i) => (
+            <WeatherTabInfo
+              key={`hourly-tab-${i}`}
+              temperature={data.temperature}
+              date={data.date}
+              dateType={DateTypes.hourly}
+            />
+          ))}
+        </CustomTabPanel>
+        <CustomTabPanel value={this.state.value} index={1}>
+          {this.props.data.daily.map((data, i) => (
+            <WeatherTabInfo
+              key={`daily-tab-${i}`}
+              temperature={data.temperature}
+              date={data.date}
+              dateType={DateTypes.daily}
+            />
+          ))}
+        </CustomTabPanel>
       </div>
     );
   }

--- a/src/components/WeatherTabs/WeatherTabs.tsx
+++ b/src/components/WeatherTabs/WeatherTabs.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { AppBar, Tabs, Tab } from '@material-ui/core';
+import CustomTabPanel from './CustomTabPanel';
+import { TabValueState } from '../../types';
+
+class WeatherTabs extends React.Component<{}, TabValueState> {
+  constructor(props: {}) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  state: TabValueState = {
+    value: 0,
+  };
+
+  a11yProps(index: number) {
+    return {
+      id: `simple-tab-${index}`,
+      'aria-controls': `simple-tabpanel-${index}`,
+    };
+  }
+
+  handleChange(event: React.ChangeEvent<{}>, newValue: number): void {
+    this.setState((state) => ({
+      value: newValue,
+    }));
+  }
+
+  render(): React.ReactNode {
+    return (
+      <div>
+        <AppBar position="static" color="secondary">
+          <Tabs
+            value={this.state.value}
+            onChange={this.handleChange}
+            aria-label="simple tabs example"
+          >
+            <Tab label="Hourly" {...this.a11yProps(0)} />
+            <Tab label="Weekly" {...this.a11yProps(1)} />
+          </Tabs>
+        </AppBar>
+        <CustomTabPanel value={this.state.value} index={0} />
+        <CustomTabPanel value={this.state.value} index={1} />
+      </div>
+    );
+  }
+}
+
+export default WeatherTabs;

--- a/src/components/WeatherTabs/WeatherTabs.tsx
+++ b/src/components/WeatherTabs/WeatherTabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AppBar, Tabs, Tab } from '@material-ui/core';
 import CustomTabPanel from './CustomTabPanel';
+import WeatherTabInfo from './WeatherTabInfo';
 import { TabValueState } from '../../types';
 
 class WeatherTabs extends React.Component<{}, TabValueState> {

--- a/src/components/WeatherTabs/WeatherTabs.tsx
+++ b/src/components/WeatherTabs/WeatherTabs.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AppBar, Tabs, Tab } from '@material-ui/core';
+import { Box, AppBar, Tabs, Tab } from '@material-ui/core';
 import CustomTabPanel from './CustomTabPanel';
 import WeatherTabInfo from './WeatherTabInfo';
 import { TabValueState, DateTypes } from '../../types';
@@ -52,10 +52,13 @@ class WeatherTabs extends React.Component<Props, TabValueState> {
             aria-label="simple tabs example"
           >
             <Tab label="Hourly" {...this.a11yProps(0)} />
-            <Tab label="Weekly" {...this.a11yProps(1)} />
+            <Tab label="Daily" {...this.a11yProps(1)} />
           </Tabs>
         </AppBar>
         <CustomTabPanel value={this.state.value} index={0}>
+          <Box component="p" pt={5} m={0} px={5}>
+            Hourly forecast is available, and based on a 24 hour clock.
+          </Box>
           {this.props.data.hourly.map((data, i) => (
             <WeatherTabInfo
               key={`hourly-tab-${i}`}
@@ -66,6 +69,9 @@ class WeatherTabs extends React.Component<Props, TabValueState> {
           ))}
         </CustomTabPanel>
         <CustomTabPanel value={this.state.value} index={1}>
+          <Box component="p" pt={5} m={0} px={5}>
+            Daily forecast is available for the following week.
+          </Box>
           {this.props.data.daily.map((data, i) => (
             <WeatherTabInfo
               key={`daily-tab-${i}`}

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,8 @@ export interface TabPanelProps {
 export interface TabValueState {
   value: number;
 }
+
+export interface WeatherTabInfoProps {
+  temperature: number;
+  date: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,3 +55,8 @@ export interface FormattedDate {
   month: string;
   year: number;
 }
+
+export enum DateTypes {
+  hourly = 'hourly',
+  daily = 'daily',
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,3 +32,13 @@ export interface FormState {
   latitude: boolean;
   longitude: boolean;
 }
+
+export interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+export interface TabValueState {
+  value: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,3 +47,11 @@ export interface WeatherTabInfoProps {
   temperature: number;
   date: number;
 }
+
+export interface FormattedDate {
+  hour: string;
+  day: string;
+  date: number;
+  month: string;
+  year: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,7 @@ export enum DateTypes {
   hourly = 'hourly',
   daily = 'daily',
 }
+
+export interface CombinedWeatherTabInfoProps extends WeatherTabInfoProps {
+  dateType: DateTypes;
+}


### PR DESCRIPTION
Created a variety of components that showcase the Hourly and Daily weather data in a tab format. Currently, only the date and temperature are shown for both of these intervals.

The data is available on the Forecast page, and is only rendered when there is a successful API call with the correct data returned. 
